### PR TITLE
sudo not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ language: cpp
 compiler:
   - gcc
 before_install:
-  - sudo pip install cpp-coveralls
+  - pip install --user cpp-coveralls
 script:
   - ./configure --enable-gcov && make && make check
 after_success:


### PR DESCRIPTION
Without `sudo`, one can use the container-based infrastructure (aka docker).